### PR TITLE
Add crop filter to config

### DIFF
--- a/src/main/java/nivoridocs/strawgolem/StrawgolemConfig.java
+++ b/src/main/java/nivoridocs/strawgolem/StrawgolemConfig.java
@@ -1,5 +1,6 @@
 package nivoridocs.strawgolem;
 
+import net.minecraft.block.Block;
 import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent.PostConfigChangedEvent;
@@ -11,7 +12,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 @EventBusSubscriber
 public class StrawgolemConfig {
 	
-	@Config.Comment("Allow the straw golems to replant a crop when they haverst it.")
+	@Config.Comment("Allow the straw golems to replant a crop when they harvest it.")
 	public static boolean replantEnabled = false;
 	
 	@Config.Comment("Set the lifespan, in tick, of new created straw golems. Set -1 for infinite.")
@@ -34,4 +35,78 @@ public class StrawgolemConfig {
 	
 	private StrawgolemConfig() {}
 
+	@Config.Comment({
+			"Sets the method for applying harvest filters.  Note that only the most specific match will be taken into consideration.",
+			"If a crop's mod appears in the whitelist, but the crop itself is in the blacklist, the crop will be banned.",
+			"Likewise if a crop's mod appears in the blacklist, but the crop itself is in the whitelist, the crop will be allowed.",
+			"\"none\": allow all crops to be harvested (default).",
+			"\"whitelist\": will deny crops from being harvested unless the most specific match is in the whitelist.",
+			"\"blacklist\": will allows crops to be harvested unless the most specific match is in the blacklist."
+	})
+	public static String filterMode = "none";
+
+	private static final String FILTER_MODE_WHITELIST = "whitelist";
+	private static final String FILTER_MODE_BLACKLIST = "blacklist";
+
+	@Config.Comment("Whitelist Filter")
+	public static String[] whitelist = new String[0];
+
+	@Config.Comment("Blacklist Filter")
+	public static String[] blacklist = new String[0];
+
+	public static boolean blockHarvestAllowed(Block block) {
+		switch (filterMode)
+		{
+		case FILTER_MODE_WHITELIST:
+			// prioritise whitelist
+			FilterMatch whitelistMatch = blockMatchesFilter(block, whitelist);
+			// if we got a whitelist match by mod, check if we're blacklisted by item
+			if (whitelistMatch == FilterMatch.Mod)
+				return blockMatchesFilter(block, blacklist) != FilterMatch.Exact;
+			return whitelistMatch != FilterMatch.None;
+
+		case FILTER_MODE_BLACKLIST:
+			// prioritise blacklist
+			FilterMatch blacklistMatch = blockMatchesFilter(block, whitelist);
+			// if we got a blacklist match by mod, check if we're whitelisted by item
+			if (blacklistMatch == FilterMatch.Mod)
+				return blockMatchesFilter(block, whitelist) == FilterMatch.Exact;
+			return blacklistMatch == FilterMatch.None;
+
+		default:
+			return true;
+		}
+	}
+
+	public static FilterMatch blockMatchesFilter(Block block, String[] filter) {
+		FilterMatch bestMatch = FilterMatch.None;
+
+		for (String s : filter) {
+			String[] elements = s.split(":");
+
+			if (elements.length == 0)
+				continue;
+
+			if (elements.length == 1 && block.getRegistryName().getResourceDomain().equals(elements[0]))
+			{
+				bestMatch = FilterMatch.Mod;
+				continue;
+			}
+
+			if (elements.length >= 2 && block.getRegistryName().getResourcePath().equals(elements[1]))
+			{
+				bestMatch = FilterMatch.Exact;
+				break;
+			}
+		}
+
+		return bestMatch;
+	}
+
+	public enum FilterMatch
+	{
+		None,
+		Mod,
+		Exact,
+	}
 }

--- a/src/main/java/nivoridocs/strawgolem/entity/EntityAIHarvest.java
+++ b/src/main/java/nivoridocs/strawgolem/entity/EntityAIHarvest.java
@@ -49,9 +49,9 @@ public class EntityAIHarvest extends EntityAIMoveToBlock {
 	@Override
 	protected boolean shouldMoveTo(World worldIn, BlockPos pos) {
 		IBlockState block = worldIn.getBlockState(pos.up());
-		if (block.getBlock() instanceof BlockCrops)
+		if (block.getBlock() instanceof BlockCrops && StrawgolemConfig.blockHarvestAllowed(block.getBlock()))
 			return ((BlockCrops) block.getBlock()).isMaxAge(block);
-		else if (block.getBlock() == Blocks.NETHER_WART)
+		else if (block.getBlock() == Blocks.NETHER_WART && StrawgolemConfig.blockHarvestAllowed(block.getBlock()))
 			return block.getValue(BlockNetherWart.AGE) == 3;
 		else return false;
 	}


### PR DESCRIPTION
Resolves #8 

Attempts to do a general match by mod, then a closer match by item.

If set to blacklist:
1) Check if the crop exists in the blacklist
2) If it matched exactly, disallow it.
2) If it matched by mod, we check the whitelist to see if it matches exactly, and if so we allow it.
3) Otherwise allow it.

If set to whitelist:
1) Check if the crop exists in the whitelist
2) If it match exactly, allow it.
2) If it matched by mod, we check the blacklist to see if it matches exactly, and if so we disallow it.
3) Otherwise disallow it.

All crops are allowed:
```
S:filterMode=none
```

All crops except potatoes are allowed:
```
S:filterMode=blacklist
S:blacklist <
    minecraft:potatoes
>
S:whitelist <
>
```

Only wheat is allowed:
```
S:filterMode=whitelist
S:blacklist <
>
S:whitelist <
    minecraft:wheat
>
```

No vanilla Minecraft crops are allowed except for potatoes, but all other mods' crops are allowed.
```
S:filterMode=blacklist
S:blacklist <
    minecraft
>
S:whitelist <
    minecraft:potatoes
>
```

All vanilla Minecraft crops are allowed except for wheat, but all other mods' crops are disallowed.
```
S:filterMode=whitelist
S:blacklist <
    minecraft:wheat
>
S:whitelist <
    minecraft
>