### PR TITLE
Fix blacklist option searching from whitelist

### DIFF
--- a/src/main/java/nivoridocs/strawgolem/StrawgolemConfig.java
+++ b/src/main/java/nivoridocs/strawgolem/StrawgolemConfig.java
@@ -67,7 +67,7 @@ public class StrawgolemConfig {
 
 		case FILTER_MODE_BLACKLIST:
 			// prioritise blacklist
-			FilterMatch blacklistMatch = blockMatchesFilter(block, whitelist);
+			FilterMatch blacklistMatch = blockMatchesFilter(block, blacklist);
 			// if we got a blacklist match by mod, check if we're whitelisted by item
 			if (blacklistMatch == FilterMatch.Mod)
 				return blockMatchesFilter(block, whitelist) == FilterMatch.Exact;


### PR DESCRIPTION
The 'blacklist' option doesn't function properly, choosing matches from the 'whitelist' set of crops instead of the 'blacklist' set. This fixes that (probably).